### PR TITLE
Removes event listeners for non-component elements

### DIFF
--- a/src/m-autocomplete.js
+++ b/src/m-autocomplete.js
@@ -1,18 +1,15 @@
 class MdashAutocomplete extends HTMLElement {
   constructor() {
     super();
+    this._boundClose = this.close.bind(this)
   }
 
   connectedCallback() {
     // Closes matching results when user clicks outside of it
-    document.body.addEventListener('click', e => {
-      if (!this.querySelector('[ref="matches"]').contains(e.currentTarget)) {
-        this.clear(true);
-      }
-    });
+    document.body.addEventListener('click', this._boundClose);
 
     // Close on esc keyup
-    document.addEventListener('keyup', e => e.key === 'Escape' ? this.clear() : null);
+    document.addEventListener('keyup', this._boundClose);
 
     this.matches = null;
 
@@ -33,6 +30,20 @@ class MdashAutocomplete extends HTMLElement {
     matches.hidden = !this.matches;
 
     this.append(input, matches);  
+  }
+
+  disconnectedCallback() {
+    document.body.removeEventListener('click', this._boundClose);
+    document.removeEventListener('keyup', this._boundClose);
+  }
+
+  close(e) {
+    if (e.type === 'keyup' && e.key === 'Escape') {
+      this.clear()
+    }
+    else if (e.type === 'click' && !this.querySelector('[ref="matches"]').contains(e.currentTarget)) {
+      this.clear(true);
+    }
   }
   
   search(query) {

--- a/src/m-dialog.js
+++ b/src/m-dialog.js
@@ -12,13 +12,14 @@
 customElements.define('m-dialog', class extends HTMLElement {
   constructor() {
     super();
+    this._boundClose = e => e.key === 'Escape' ? this.close() : null;
   }
 
   connectedCallback() {
     this.returnValue = null;
 
     // Close on esc keyup
-    document.addEventListener('keyup', e => e.key === 'Escape' ? this.close() : null);
+    document.addEventListener('keydown', this._boundClose);
 
     // One time render stuff
     const container = document.createElement('div');
@@ -39,6 +40,10 @@ customElements.define('m-dialog', class extends HTMLElement {
 
     container.append(closeBtn, content1);
     this.append(container);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('keydown', this._boundClose);
   }
 
   static get observedAttributes() { return ['open']; }

--- a/src/m-menu.js
+++ b/src/m-menu.js
@@ -1,6 +1,7 @@
 customElements.define('m-menu', class extends HTMLElement {
   constructor() {
     super();
+    this._boundClose = this.close.bind(this)
   }
 
   connectedCallback() {
@@ -8,12 +9,19 @@ customElements.define('m-menu', class extends HTMLElement {
     this.trigger.addEventListener('click', e => this.open = !this.open);
 
     // Close menu if user clicks outside of a menu or navigates away
-    // TODO This adds a click handler to body for each menu instance...probably not ideal
-    // TODO popstate is ineffective if the link was a child of the menu
-    document.body.addEventListener('click', e => {
-      if (!this.contains(e.target)) this.open = false
-    });
-    window.addEventListener('popstate', () => this.open = false);
+    document.body.addEventListener('click', this._boundClose);
+    window.addEventListener('popstate', this._boundClose); // TODO popstate is ineffective if the link was a child of the menu
+  }
+
+  disconnectedCallback() {
+    document.body.removeEventListener('click', this._boundClose);
+    window.removeEventListener('popstate', this._boundClose);
+  }
+
+  close(e) {
+    if (e && e.type === 'popstate' || !this.contains(e.target)) {
+      this.open = false
+    }
   }
 
   static get observedAttributes() { return ['open']; }


### PR DESCRIPTION
Events added to the element itself or its children are garbage-collected, so no explicit removal is needed. Only these outside listeners (document, window, body).