### PR TITLE
Icons inherit font weight by default

### DIFF
--- a/src/m-icons.css
+++ b/src/m-icons.css
@@ -10,7 +10,7 @@ m-icon {
   font-family: 'm-icons';
   speak: none;
   font-style: normal;
-  font-weight: normal;
+  font-weight: inherit;
   font-variant: normal;
   text-transform: none;
   line-height: 1;


### PR DESCRIPTION
More often than not the weight of icons looks better when matching related text's font weight. It is true that the current icons are too thin to begin with, but this change matches expected results for the time being.